### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ after_success: npm run coveralls
 language: node_js
 
 node_js:
-  - "4.0"
   - "4"
   - "5"
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ exports.register = function (server, options, next) {
 
     const plugins = [{
         register: Henning,
-        options: options
+        options
     }, {
         register: Recourier,
         options: {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://github.com/ruiquelhas/burton#readme",
   "devDependencies": {
-    "code": "3.x.x",
+    "code": "4.x.x",
     "content": "3.x.x",
     "coveralls": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x",
-    "multi-part": "1.x.x"
+    "hapi": "15.x.x",
+    "lab": "11.x.x",
+    "multi-part": "2.x.x"
   },
   "dependencies": {
     "henning": "2.x.x",
@@ -42,6 +42,6 @@
     "subtext": "4.x.x"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.5.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -83,7 +83,7 @@ lab.experiment('burton', () => {
         const form = new Form();
         form.append('file', Fs.createReadStream(png));
 
-        server.inject({ headers: { 'Content-Type': 'application/json' }, method: 'POST', payload: form.get(), url: '/main' }, (response) => {
+        server.inject({ headers: { 'Content-Type': 'application/json' }, method: 'POST', payload: form.stream(), url: '/main' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(415);
             Code.expect(response.headers['content-validation']).to.not.exist();
@@ -101,7 +101,7 @@ lab.experiment('burton', () => {
         form.append('file2', Fs.createReadStream(png));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/main' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/main' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             Code.expect(response.headers['content-validation']).to.equal('success');

--- a/test/index.js
+++ b/test/index.js
@@ -78,7 +78,7 @@ lab.experiment('burton', () => {
     lab.test('should return error if the payload cannot be parsed', (done) => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file', Fs.createReadStream(png));
@@ -94,7 +94,7 @@ lab.experiment('burton', () => {
     lab.test('should return control to the server if all files the in payload are allowed', (done) => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(png));


### PR DESCRIPTION
Update 3rd-party modules and supported node engine. Switch to the new `Buffer` API available since `v4.5.0`.